### PR TITLE
Change archive format for pre-built binary

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -122,8 +122,8 @@ jobs:
           gzip -k -v -9 "${package}.tar"
           lzip -v -9 "${package}.tar"
         else
-          7z a -bb -mx=9 "${package}.7z" "${package}"
-          7z a -bb -mx=9 "${package}.zip" "${package}"
+          7z a -bb -mx=9 -m0=LZMA "${package}.7z" "${package}"
+          7z a -bb -mx=9 -mm=Deflate "${package}.zip" "${package}"
         fi
         rm -rv qrtool-*/
     - name: Upload artifact

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,6 +21,8 @@ toc::[]
 === Changed
 
 * Update documentation ({pull-request-url}/179[#179])
+* Use LZMA instead of LZMA2 in 7z format for pre-built binary
+  ({pull-request-url}/181[#181])
 
 == {compare-url}/v0.7.3\...v0.7.4[0.7.4] - 2023-08-03
 


### PR DESCRIPTION
Use LZMA instead of LZMA2 in 7z format.