### PR TITLE
Add Arch Linux instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,9 +264,9 @@ licensing information.
 [repology-versions]: https://repology.org/project/qrtool/versions
 [Homebrew]: https://brew.sh/
 [Nix]: https://nixos.org/
-[_openSUSE_]: https://www.opensuse.org/
 [_Arch Linux_]: https://archlinux.org/
 [Pacman]: https://wiki.archlinux.org/title/pacman
+[_openSUSE_]: https://www.opensuse.org/
 [release page]: https://github.com/sorairolake/qrtool/releases
 [BUILD.adoc]: BUILD.adoc
 [CSS color string]: https://www.w3.org/TR/css-color-4/

--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ cargo install qrtool
 
 [![Packaging status][repology-badge]][repology-versions]
 
-| OS           | Package manager | Command                               |
-| ------------ | --------------- | ------------------------------------- |
-| _Any_        | [Homebrew]      | `brew install sorairolake/tap/qrtool` |
-| _Any_        | [Nix]           | `nix-env -iA nixpkgs.qrtool`          |
-| [_openSUSE_] | Zypper          | `zypper install qrtool`               |
+| OS             | Package manager | Command                               |
+| -------------- | --------------- | ------------------------------------- |
+| _Any_          | [Homebrew]      | `brew install sorairolake/tap/qrtool` |
+| _Any_          | [Nix]           | `nix-env -iA nixpkgs.qrtool`          |
+| [_openSUSE_]   | Zypper          | `zypper install qrtool`               |
+| [_Arch Linux_] | [Pacman]        | `pacman -S qrtool`                    |
 
 ### From binaries
 
@@ -156,7 +157,6 @@ QR code
 ```
 
 [^ico-note]: CUR is also supported.
-
 [^svg-note]: SVGZ is also supported.
 
 ### Generate shell completion
@@ -265,6 +265,8 @@ licensing information.
 [Homebrew]: https://brew.sh/
 [Nix]: https://nixos.org/
 [_openSUSE_]: https://www.opensuse.org/
+[_Arch Linux_]: https://archlinux.org/
+[Pacman]: https://wiki.archlinux.org/title/pacman
 [release page]: https://github.com/sorairolake/qrtool/releases
 [BUILD.adoc]: BUILD.adoc
 [CSS color string]: https://www.w3.org/TR/css-color-4/

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ cargo install qrtool
 | -------------- | --------------- | ------------------------------------- |
 | _Any_          | [Homebrew]      | `brew install sorairolake/tap/qrtool` |
 | _Any_          | [Nix]           | `nix-env -iA nixpkgs.qrtool`          |
-| [_openSUSE_]   | Zypper          | `zypper install qrtool`               |
 | [_Arch Linux_] | [Pacman]        | `pacman -S qrtool`                    |
+| [_openSUSE_]   | Zypper          | `zypper install qrtool`               |
 
 ### From binaries
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ QR code
 ```
 
 [^ico-note]: CUR is also supported.
+
 [^svg-note]: SVGZ is also supported.
 
 ### Generate shell completion


### PR DESCRIPTION
## Description

`qrtool` is now packaged in the official Arch Linux repositories: <https://archlinux.org/packages/extra/x86_64/qrtool/> 🥳

## Checklist

- [x] I have read the [Contribution Guide].
- [x] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/qrtool/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/qrtool/blob/develop/CODE_OF_CONDUCT.md
