### PR TITLE
Add pic support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "qrcode"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e719ca51966ff9f5a8436edb00d6115b3c606a0bb27c8f8ca74a38ff2b036d"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
 dependencies = [
  "image",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ clap_complete_nushell = "4.5.2"
 csscolorparser = "0.6.2"
 image = { version = "0.25.1", default-features = false, features = ["png", "rayon"] }
 oxipng = { version = "9.1.1", default-features = false, features = ["parallel", "zopfli"], optional = true }
-qrcode = "0.14.0"
+qrcode = "0.14.1"
 resvg = { version = "0.42.0", default-features = false, optional = true }
 rqrr = "0.7.1"
 sysexits = "0.8.1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -75,7 +75,7 @@ pub fn run() -> anyhow::Result<()> {
                         .unwrap_or_else(|| if code.version().is_micro() { 2 } else { 4 });
                 let module_size = arg.size.map(NonZeroU32::get);
                 match arg.output_format {
-                    format @ (OutputFormat::Svg | OutputFormat::Terminal) => {
+                    format @ (OutputFormat::Pic | OutputFormat::Svg | OutputFormat::Terminal) => {
                         let string = if format == OutputFormat::Svg {
                             encode::to_svg(
                                 &code,
@@ -83,6 +83,8 @@ pub fn run() -> anyhow::Result<()> {
                                 &(arg.foreground, arg.background),
                                 module_size,
                             )
+                        } else if format == OutputFormat::Pic {
+                            encode::to_pic(&code, margin, module_size)
                         } else {
                             encode::to_terminal(&code, margin, module_size)
                         };

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -389,7 +389,7 @@ impl From<Ecc> for qrcode::EcLevel {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, ValueEnum)]
 pub enum OutputFormat {
-    /// PIC markup language
+    /// PIC markup language.
     Pic,
 
     /// Portable Network Graphics.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -389,6 +389,9 @@ impl From<Ecc> for qrcode::EcLevel {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, ValueEnum)]
 pub enum OutputFormat {
+    /// PIC markup language
+    Pic,
+
     /// Portable Network Graphics.
     ///
     /// This outputs 32-bit RGBA PNG image.

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -53,16 +53,12 @@ pub fn push_data_for_selected_mode(
 
 /// Renders the QR code into a PIC image.
 pub fn to_pic(code: &QrCode, margin: u32, module_size: Option<u32>) -> String {
-    let mut result = String::new();
+    let c = code.to_colors();
+    let mut renderer = &mut Renderer::<pic::Color>::new(&c, code.width(), margin);
     if let Some(size) = module_size {
-        result = code
-            .render::<pic::Color>()
-            .min_dimensions(size, size)
-            .build();
-    } else {
-        result = code.render::<pic::Color>().build();
+        renderer = renderer.module_dimensions(size, size);
     }
-    return result;
+    renderer.build()
 }
 
 /// Renders the QR code into an image.

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -6,7 +6,7 @@ use csscolorparser::Color;
 use image::{Rgba, RgbaImage};
 use qrcode::{
     bits::Bits,
-    render::{svg, unicode, Renderer},
+    render::{pic, svg, unicode, Renderer},
     types::QrError,
     EcLevel, QrCode, QrResult, Version,
 };
@@ -49,6 +49,20 @@ pub fn push_data_for_selected_mode(
         Mode::Byte => bits.push_byte_data(data),
         Mode::Kanji => bits.push_kanji_data(data),
     }
+}
+
+/// Renders the QR code into a PIC image.
+pub fn to_pic(code: &QrCode, margin: u32, module_size: Option<u32>) -> String {
+    let mut result = String::new();
+    if let Some(size) = module_size {
+        result = code
+            .render::<pic::Color>()
+            .min_dimensions(size, size)
+            .build();
+    } else {
+        result = code.render::<pic::Color>().build();
+    }
+    return result;
 }
 
 /// Renders the QR code into an image.


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->

Add support for PIC output format, which was added to [`qrcode-rust` `0.14.1`](https://github.com/kennytm/qrcode-rust/releases/tag/v0.14.1) (released July 5th) with [`kennytm/qrcode-rust#65`](https://github.com/kennytm/qrcode-rust/pull/65).

Unfortunately my Rust expertise is rather lacking, hence the crude implementation. I'd greatly appreciated advice and guidance on how to improve this PR. I'm dissatisfied with the `if-else` in order to handle the given `module_size` and dislike that therefore `margin` is ignored.

Trying to follow the same approach as `to_svg` and call `module_dimensions` on a previously created renderer:

```rust
pub fn to_pic(code: &QrCode, margin: u32, module_size: Option<u32>) -> String {
    let c = code.to_colors();
    let mut renderer = Renderer::<pic::Color>::new(&c, code.width(), margin);
    let mut result = String::new();
    if let Some(size) = module_size {
        renderer = renderer.module_dimensions(size, size);
    }
    renderer.build();
}
```

result in the following error for me:

```
error[E0308]: mismatched types
  --> src/encode.rs:60:20
   |
57 |     let mut renderer = Renderer::<pic::Color>::new(&c, code.width(), margin);
   |                        ----------------------------------------------------- expected due to this value
...
60 |         renderer = renderer.module_dimensions(size, size);
   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Renderer<'_, Color>`, found `&mut Renderer<'_, ...>`
   |
   = note:         expected struct `Renderer<'_, _>`
           found mutable reference `&mut Renderer<'_, _>`
```

Hopefully I've been able to explain well, what I'd like to achieve and which errors I run into, if not please ask me to clarify 🙂 

ℹ️ This PR includes the changes from #539 (pending review and approval) to update `qrcode-rust` to `0.14.1`

## Additional context

> _Pic is a [domain-specific] programming language by Brian Kernighan for specifying line diagrams._

— [Wikipedia](https://en.wikipedia.org/wiki/PIC_(markup_language))

It is most commonly used in typesetting documents using implementations of roff, such as [GNU roff](https://www.gnu.org/software/groff/), [Plan 9 troff](https://github.com/n-t-roff/Plan9_troff), or [heirloom doctools](https://github.com/n-t-roff/heirloom-doctools) to name a few.

## Checklist

- [x] I have read the [Contribution Guide].
- [x] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/qrtool/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/qrtool/blob/develop/CODE_OF_CONDUCT.md
