### PR TITLE
refactor: Restrict input data size to 7,090 bytes when encoding

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,13 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/[Keep a Changelog], and this
 project adheres to https://semver.org/[Semantic Versioning].
 
+== {compare-url}/v0.11.3\...HEAD[Unreleased]
+
+=== Changed
+
+* Read only the first 7,090 bytes of the input data when encoding
+  ({pull-request-url}/585[#585])
+
 == {compare-url}/v0.11.2\...v0.11.3[0.11.3] - 2024-07-22
 
 === Changed

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2024 Shun Sakai
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::{
+    fs::File,
+    io::{self, Cursor, Read, Stdin},
+};
+
+#[derive(Debug)]
+pub enum Input {
+    String(Cursor<String>),
+    File(File),
+    Stdin(Stdin),
+}
+
+impl Read for Input {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match *self {
+            Self::String(ref mut string) => string.read(buf),
+            Self::File(ref mut file) => file.read(buf),
+            Self::Stdin(ref mut stdin) => stdin.read(buf),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod app;
 mod cli;
 mod decode;
 mod encode;
+mod input;
 mod metadata;
 
 use std::{io, process::ExitCode};

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -107,9 +107,7 @@ fn encode_from_non_existent_file() {
         .assert()
         .failure()
         .code(66)
-        .stderr(predicate::str::contains(
-            "could not read data from non_existent.txt",
-        ));
+        .stderr(predicate::str::contains("could not open non_existent.txt"));
     if cfg!(windows) {
         command.stderr(predicate::str::contains(
             "The system cannot find the file specified. (os error 2)",


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
The numeric mode can store numbers up to 7,089 digits. So, data larger than 7,089 bytes cannot be encoded (without considering UTF-16 and UTF-32).

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/qrtool/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/qrtool/blob/develop/CODE_OF_CONDUCT.md
